### PR TITLE
Add stack traces when there are errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  NewCops: enable
   TargetRubyVersion: 2.5
 
 Metrics/BlockLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.5
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0 (unreleased)
+
+- Add stack traces when there is an error during evaluation.
+
 ## 1.0.0 (2019-06-06)
 
 First release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 2.0.0 (unreleased)
 
--  *BREAKING CHANGE* Drop support for Ruby < 2.5
--  Add stack traces when there is an error during evaluation.
+-   **BREAKING CHANGE** Drop support for Ruby &lt; 2.5
+-   Add stack traces when there is an error during evaluation.
 
 ## 1.0.0 (2019-06-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 1.1.0 (unreleased)
+## 2.0.0 (unreleased)
 
-- Add stack traces when there is an error during evaluation.
+-  *BREAKING CHANGE* Drop support for Ruby < 2.5
+-  Add stack traces when there is an error during evaluation.
 
 ## 1.0.0 (2019-06-06)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ change, please consider opening an issue to discuss it first.
 Install the dependencies:
 
 ```bash
-$ bundle
+bundle
 ```
 
 Done.
@@ -23,7 +23,7 @@ We have 100% test coverage using rspec and SimpleCov.
 You can run the tests by simply running
 
 ```bash
-$ rspec
+rspec
 ```
 
 ## Deploying

--- a/README.md
+++ b/README.md
@@ -184,6 +184,13 @@ Then you could run a complex expression like this:
 => "Howdy Billy"
 ```
 
+## Errors
+
+When evaluating Conflisp expressions, there are two types of errors that can be
+raised:
+
+- `Conflisp::MethodMissing` - raised if a method isn't defined in the language
+- `Conflisp::RuntimeError` - raised if there was an error during evaluation
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ Then you could run a complex expression like this:
 When evaluating Conflisp expressions, there are two types of errors that can be
 raised:
 
-- `Conflisp::MethodMissing` - raised if a method isn't defined in the language
-- `Conflisp::RuntimeError` - raised if there was an error during evaluation
+-   `Conflisp::MethodMissing` - raised if a method isn't defined in the language
+-   `Conflisp::RuntimeError` - raised if there was an error during evaluation
 
 ## License
 

--- a/conflisp.gemspec
+++ b/conflisp.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
     *Dir['lib/conflisp/*.rb']
   ]
 
+  s.required_ruby_version = '>= 2.5'
+
   s.add_development_dependency 'rspec', '~> 3.7.0'
   s.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'
   s.add_development_dependency 'rubocop', '~> 0.71.0'

--- a/conflisp.gemspec
+++ b/conflisp.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec', '~> 3.7.0'
   s.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'
-  s.add_development_dependency 'rubocop', '~> 0.71.0'
+  s.add_development_dependency 'rubocop', '~> 0.93.1'
   s.add_development_dependency 'simplecov', '~> 0.16.1'
 end

--- a/lib/conflisp/conflisp_error.rb
+++ b/lib/conflisp/conflisp_error.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
 module Conflisp
-  ConflispError = Class.new(StandardError)
+  # Base class for ConflispError
+  class ConflispError < StandardError
+    attr_reader :conflisp_stack
+
+    def initialize(*args)
+      super
+
+      @conflisp_stack = []
+    end
+
+    def to_s
+      ret = super
+
+      conflisp_stack.each do |expression|
+        ret += "\n  in expression #{expression}"
+      end
+
+      ret
+    end
+  end
 end

--- a/lib/conflisp/method_missing.rb
+++ b/lib/conflisp/method_missing.rb
@@ -3,5 +3,11 @@
 require 'conflisp/conflisp_error'
 
 module Conflisp
-  MethodMissing = Class.new(ConflispError)
+  # Error raised when a function is not found
+  class MethodMissing < ConflispError
+    def initialize(fn_name)
+      message = "Unknown fn `#{fn_name}`"
+      super(message)
+    end
+  end
 end

--- a/lib/conflisp/runtime_error.rb
+++ b/lib/conflisp/runtime_error.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'conflisp/conflisp_error'
+
+module Conflisp
+  # Error raised when evaluation of a Conflisp expression fails
+  class RuntimeError < ConflispError
+    attr_reader :original_error
+
+    def initialize(error, expression)
+      message = "#{error.class.name}: #{error.message}"
+      message += "\n  while evaluating #{expression}"
+      super(message)
+
+      @original_error = error
+    end
+  end
+end

--- a/spec/conflisp/evaluator_spec.rb
+++ b/spec/conflisp/evaluator_spec.rb
@@ -46,15 +46,6 @@ RSpec.describe Conflisp::Evaluator do
       expect(evaluator.resolve(expression)).to eq('foo' => 3)
     end
 
-    context 'when calling nonexistent functions' do
-      it 'throws an error' do
-        message = 'Unknown fn nonexistent in expression ["nonexistent", 1, 2]'
-        expect {
-          evaluator.resolve(['nonexistent', 1, 2])
-        }.to raise_error(Conflisp::MethodMissing, message)
-      end
-    end
-
     context 'when passing in globals' do
       let(:globals) do
         {
@@ -86,6 +77,92 @@ RSpec.describe Conflisp::Evaluator do
 
       it 'will allow you to resolve expressions' do
         expect(evaluator.resolve(['add2', 1, 2])).to eq(3)
+      end
+    end
+
+    context 'when calling nonexistent functions' do
+      let(:expr) { ['nonexistent', 1, 2] }
+
+      it 'raises a Conflisp::MethodMissing error' do
+        expect {
+          evaluator.resolve(expr)
+        }.to raise_error(Conflisp::MethodMissing)
+      end
+
+      it 'includes a stacktrace in the message' do
+        expect {
+          evaluator.resolve(expr)
+        }.to(raise_error { |error|
+          # Using <<~ would require minimum Ruby 2.3, but it seems silly to add
+          # that restriction just for the tests.
+          # rubocop:disable Layout/IndentHeredoc
+          message = <<-TXT
+Unknown fn `nonexistent`
+  in expression ["nonexistent", 1, 2]
+          TXT
+          # rubocop:enable Layout/IndentHeredoc
+          expect(error.message).to eq(message.strip)
+        })
+      end
+    end
+
+    context 'when there is an error in execution' do
+      let(:registry) do
+        {
+          'add' => ->(a, b) { a + b },
+          'divide' => ->(a, b) { a / b }
+        }
+      end
+
+      let(:expr) do
+        {
+          'foo' => [
+            'add',
+            1,
+            [
+              'divide',
+              1,
+              [
+                'add',
+                -1,
+                1
+              ]
+            ]
+          ]
+        }
+      end
+
+      it 'raises a Conflisp::ConflispError' do
+        expect {
+          evaluator.resolve(expr)
+        }.to raise_error(Conflisp::RuntimeError)
+      end
+
+      it 'includes the original error in the exception' do
+        expect {
+          evaluator.resolve(expr)
+        }.to(raise_error { |error|
+          expect(error.original_error).to be_a(ZeroDivisionError)
+        })
+      end
+
+      it 'includes a stacktrace in the message' do
+        expect {
+          evaluator.resolve(expr)
+        }.to(raise_error { |error|
+          # Using <<~ would require minimum Ruby 2.3, but it seems silly to add
+          # that restriction just for the tests.
+          # rubocop:disable Layout/IndentHeredoc
+          message = <<-TXT
+ZeroDivisionError: divided by 0
+  while evaluating ["divide", 1, 0]
+  in expression ["divide", 1, ["add", -1, 1]]
+  in expression ["add", 1, ["divide", 1, ["add", -1, 1]]]
+  in expression {"foo"=>["add", 1, ["divide", 1, ["add", -1, 1]]]}
+          TXT
+          # rubocop:enable Layout/IndentHeredoc
+          expect(error.message).to eq(message.strip)
+        })
       end
     end
   end

--- a/spec/conflisp/evaluator_spec.rb
+++ b/spec/conflisp/evaluator_spec.rb
@@ -93,14 +93,10 @@ RSpec.describe Conflisp::Evaluator do
         expect {
           evaluator.resolve(expr)
         }.to(raise_error { |error|
-          # Using <<~ would require minimum Ruby 2.3, but it seems silly to add
-          # that restriction just for the tests.
-          # rubocop:disable Layout/IndentHeredoc
-          message = <<-TXT
-Unknown fn `nonexistent`
-  in expression ["nonexistent", 1, 2]
+          message = <<~TXT
+            Unknown fn `nonexistent`
+              in expression ["nonexistent", 1, 2]
           TXT
-          # rubocop:enable Layout/IndentHeredoc
           expect(error.message).to eq(message.strip)
         })
       end
@@ -150,17 +146,13 @@ Unknown fn `nonexistent`
         expect {
           evaluator.resolve(expr)
         }.to(raise_error { |error|
-          # Using <<~ would require minimum Ruby 2.3, but it seems silly to add
-          # that restriction just for the tests.
-          # rubocop:disable Layout/IndentHeredoc
-          message = <<-TXT
-ZeroDivisionError: divided by 0
-  while evaluating ["divide", 1, 0]
-  in expression ["divide", 1, ["add", -1, 1]]
-  in expression ["add", 1, ["divide", 1, ["add", -1, 1]]]
-  in expression {"foo"=>["add", 1, ["divide", 1, ["add", -1, 1]]]}
+          message = <<~TXT
+            ZeroDivisionError: divided by 0
+              while evaluating ["divide", 1, 0]
+              in expression ["divide", 1, ["add", -1, 1]]
+              in expression ["add", 1, ["divide", 1, ["add", -1, 1]]]
+              in expression {"foo"=>["add", 1, ["divide", 1, ["add", -1, 1]]]}
           TXT
-          # rubocop:enable Layout/IndentHeredoc
           expect(error.message).to eq(message.strip)
         })
       end


### PR DESCRIPTION
This makes it a little easier to debug when you have big complicated
expressions.

RuntimeError:
![image](https://user-images.githubusercontent.com/21784/95769213-88309100-0c85-11eb-8592-7c4a33a09667.png)
![image](https://user-images.githubusercontent.com/21784/95769359-c2019780-0c85-11eb-85a1-c30119e2c556.png)

MethodMissing:
![image](https://user-images.githubusercontent.com/21784/95769415-d6459480-0c85-11eb-9b5b-c7953c752e7e.png)