### PR TITLE
bump rspec-core version to handle deprecation warnings

### DIFF
--- a/conflisp.gemspec
+++ b/conflisp.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_development_dependency 'rspec', '~> 3.7.0'
+  s.add_development_dependency 'rspec', '~> 3.12.0'
   s.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'
   s.add_development_dependency 'rubocop', '~> 0.93.1'
   s.add_development_dependency 'simplecov', '~> 0.19.0'


### PR DESCRIPTION
Tested this repo with Ruby 3.2 installed and noticed deprecation warnings when running the test suite.
This PR bumps the rspec-core version to take care of them.